### PR TITLE
Optional mod aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,18 @@ for pure replacement mods (lacking an ESP) will not be preserved when the respec
 When the save function is invoked, the INI and `Plugins` files will be modified accordingly and saved to the SD card.
 
 ### Changes Made To Original Work
-1. Change all suffixes to be single letter only. 
-- For example, `EnaiRim - Textures` should now be formatted as `EnaiRim - T`.
+1. Changed all suffixes to be single letter only. 
+    - For example, `EnaiRim - Textures` should now be formatted as `EnaiRim - T`.
+    - The `Skyrim.ini` file has a line limit of 1024 characters, which can be hit very quickly if we use the lengthy original suffixes scheme on NexusMods (I hit it around 16 mods, even with succinct base modnames).
+    - This change hence aims to remove all of that unnecessary character bloat from the `skyrim.ini` configuration file so that more mods can be loaded.
 
-- The skyrim.ini file has a line limit of 1024 characters, which can be hit very quickly if we use the lengthy original suffixes scheme on NexusMods (I hit it around 16 mods, even with succinct base modnames).
+2. Added a feature to give each mod an in-app alias. Pressing `X` while hovering over a mod prompts user to add an alias to the mod, which will then be saved to disk and then loaded up the next time. Entering an empty alias will delete the current alias, if any, associated with the selected mod. The aliases will be saved in a human-readable format in `skymm-alias.txt` within the same folder. which the user can opt to edit directly instead of going through the app.
+    - eg. Mod `A` as displayed in-app can now be given the alias `Crossbows of Skyrim`, which will display in-app as `A (Crossbows of Skyrim)`. The alias will be saved in a human-readable format in `skymm-alias.txt` within the same folder. The user can opt to edit the `.txt` directly.
+    - Allows user to shorten base names of mods as much as they want without runnning the risk 
 
-- This change hence aims to remove all of that unnecessary character bloat from the `skyrim.ini` configuration file so that more mods can be loaded.
+3. Small fix to suffix checking for Animations.
 
-2. Very small under-the-hood fixes
+The main application was not made by me. All credit for that goes to [caseif](https://github.com/caseif/SkyMM-NX).
 
 ### Naming Scheme (updated)
 
@@ -41,8 +45,11 @@ Currently, the app requires that all mods follow a standard naming scheme:
 
 ### To-do
 
-- Add ability to 'nickname' or give aliases to mods in-app or on PC via a `.txt` so that it's easier to identify truncated modnames (so that you don't come back to the game after 5 years and start wondering what `E.esp` does)
-- Add a python or bash script to automatically to automatically detect and truncate all suffixes in a folder
+* COMPLETED - <strike> Add ability to 'nickname' or give aliases to mods in-app or on PC via a `.txt` so that it's easier to identify truncated modnames (so that you don't come back to the game after 5 years and start wondering what `E.esp` does) </strike>
+* Add an in-app function to rename all `.bsa` and `.esp` files in the `Data/` folder to short names like `a.esp`, then automatically generating aliases for all renamed mods that did not previously have an alias, based on their original filename
+    - eg 1. `Mod1` will be become `A (Mod1)` in-app, and its associated `.esp` file will be renamed from `Mod1.esp` to `A.esp` (along with its other files)
+    - eg 2. `Mod2 (Aho Project)` will become `B (Aho Project)` in-app (no change to alias since it already has one), and its associated `.esp` file will be renamed from `Mod2.esp` to `B.esp` (along with its other files)
+* Fix/Tweak `.ini` writing. According to the author of Skyrim-NX-Toolkit, textures and voices `.bsa` files are supposed to go under `sResourceArchiveList2=` in `Skyrim.ini` instead of `sArchiveToLoadInMemoryList=`. The current app just adds them all under the latter, but for some reason still works perfectly fine. Even so, by distributing the `.bsa` files as per the Skyrim-NX-Toolkit method, we can reduce more bloat from the `sArchiveToLoadInMemoryList=`, which should prevent us from hitting the 1024 limit earlier.
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -9,25 +9,37 @@ for pure replacement mods (lacking an ESP) will not be preserved when the respec
 
 When the save function is invoked, the INI and `Plugins` files will be modified accordingly and saved to the SD card.
 
+### Changes made to original work
+Change all suffix to be single letter only. For example, `EnaiRim - Textures` should now be formatted as `EnaiRim - T`.
+
+The skyrim.ini file has a line limit of 1024 characters, which can be hit very quickly if we use the lengthy original suffixes (I hit it around 16 mods, even with succinct base modnames).
+
+This change hence aims to remove all of that unnecessary character bloat from the skyrim.ini configuration file so that more mods can be loaded.
+
+### Naming Scheme (updated)
+
 Currently, the app requires that all mods follow a standard naming scheme:
 
+- All suffixes in filenames are to be truncated to one-letter only
+  - `Mod - Animations.bsa` to be renamed `Mod - A.bsa`
+  - `Mod - Meshes.bsa` to be renamed `Mod - M.bsa`
+  - `Mod - Sounds.bsa` to be renamed `Mod - S.bsa`
+  - `Mod - Textures.bsa` to be renamed `Mod - T.bsa`
+  - `Mod - Voices.bsa` to be renamed `Mod - V.bsa`
+  - Additional Tip: You can further replace the basename `Mod` with something even shorter like `M` - just use common sense and make sure it doesn't conflict with the basename of another mod.
+
 - BSA files with a suffix must use a hyphen with one space on either side between the base name and the suffix
-  - Example: `Static Mesh Improvement Mod - Textures.bsa`
+  - Example: `Static Mesh Improvement Mod - T.bsa`
   - Note that a mod may have exactly one non-suffixed BSA file
 - BSA files with an associated ESP file must match the ESP's name, not including the suffix
-  - Example: `Static Mesh Improvement Mod - Textures.bsa` matches `Static Mesh Improvement Mod.esp`
+  - Example: `Static Mesh Improvement Mod - T.bsa` matches `Static Mesh Improvement Mod.esp`
 - All BSA files for a given mod must match each other in name
-  - Example: `Static Mesh Improvement Mod - Textures.bsa` matches `Static Mesh Improvement Mod - Meshes.bsa`
+  - Example: `Static Mesh Improvement Mod - T.bsa` matches `Static Mesh Improvement Mod - M.bsa`
 
 ### To-do
 
-- Graceful error handling
-  - I've done minimal edge testing so far, so the app probably won't respond well to most less-than-ideal
-    conditions (e.g. missing or malformed files)
-- Proper graphical interface
-  - This isn't high priority since the console interface seems to work well enough for now
-- INI injection support
-  - Injecting INIs is easy; the hard part is disabling them in a sane way
+- Add ability to 'nickname' or give aliases to mods so that it's easier to identify truncated modnames.
+- Add a python or bash script to automatically to automatically detect and truncate all suffixes in a folder
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,15 @@ for pure replacement mods (lacking an ESP) will not be preserved when the respec
 
 When the save function is invoked, the INI and `Plugins` files will be modified accordingly and saved to the SD card.
 
-### Changes made to original work
-Change all suffix to be single letter only. For example, `EnaiRim - Textures` should now be formatted as `EnaiRim - T`.
+### Changes Made To Original Work
+1. Change all suffixes to be single letter only. 
+- For example, `EnaiRim - Textures` should now be formatted as `EnaiRim - T`.
 
-The skyrim.ini file has a line limit of 1024 characters, which can be hit very quickly if we use the lengthy original suffixes (I hit it around 16 mods, even with succinct base modnames).
+- The skyrim.ini file has a line limit of 1024 characters, which can be hit very quickly if we use the lengthy original suffixes scheme on NexusMods (I hit it around 16 mods, even with succinct base modnames).
 
-This change hence aims to remove all of that unnecessary character bloat from the skyrim.ini configuration file so that more mods can be loaded.
+- This change hence aims to remove all of that unnecessary character bloat from the `skyrim.ini` configuration file so that more mods can be loaded.
+
+2. Very small under-the-hood fixes
 
 ### Naming Scheme (updated)
 
@@ -38,7 +41,7 @@ Currently, the app requires that all mods follow a standard naming scheme:
 
 ### To-do
 
-- Add ability to 'nickname' or give aliases to mods so that it's easier to identify truncated modnames.
+- Add ability to 'nickname' or give aliases to mods in-app or on PC via a `.txt` so that it's easier to identify truncated modnames (so that you don't come back to the game after 5 years and start wondering what `E.esp` does)
 - Add a python or bash script to automatically to automatically detect and truncate all suffixes in a folder
 
 ### Building

--- a/include/alias_manager.hpp
+++ b/include/alias_manager.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "file_helper.hpp"
+#include "string_helper.hpp"
+
+#define SEPARATOR_TOKEN ","
+#define SPACE " "
+#define NEWLINE "\n"
+
+class alias_manager {
+
+public:
+    static alias_manager *getInstance();
+
+    bool has_alias(std::string filename);
+    std::string get_alias(std::string filename);
+    void set_alias(std::string filename, std::string alias);
+    void remove_alias(std::string filename);
+    void load_saved_alias(std::string filepath);
+    void save_alias_list_to_disk(std::string dest);
+    
+
+private:
+    static alias_manager *instance;
+    std::unordered_map<std::string, std::string> filename_to_alias_mapping;
+
+    alias_manager();
+
+    class alias_parser {
+    public:
+        void parse(std::string text);
+        std::string convert_to_text(std::unordered_map<std::string, std::string> &alias_list);
+    };
+
+    alias_parser parser;
+
+};

--- a/include/alias_manager.hpp
+++ b/include/alias_manager.hpp
@@ -7,37 +7,38 @@
 #include <vector>
 
 #include "file_helper.hpp"
+#include "path_helper.hpp"
 #include "string_helper.hpp"
 
-#define SEPARATOR_TOKEN ","
+#define SEPARATOR_TOKEN "," // token must be illegal in filenames
 #define SPACE " "
 #define NEWLINE "\n"
 
-class alias_manager {
+class AliasManager {
 
 public:
-    static alias_manager *getInstance();
+    static AliasManager *get_instance();
 
     bool has_alias(std::string filename);
     std::string get_alias(std::string filename);
     void set_alias(std::string filename, std::string alias);
     void remove_alias(std::string filename);
-    void load_saved_alias(std::string filepath);
-    void save_alias_list_to_disk(std::string dest);
+    void load_saved_alias(std::string filepath=SKYMM_NX_ALIAS_TXT_FILE);
+    void save_alias_list_to_disk(std::string dest=SKYMM_NX_ALIAS_TXT_FILE);
     
 
 private:
-    static alias_manager *instance;
+    static AliasManager *instance;
     std::unordered_map<std::string, std::string> filename_to_alias_mapping;
 
-    alias_manager();
+    AliasManager();
 
-    class alias_parser {
+    class AliasParser {
     public:
         void parse(std::string text);
         std::string convert_to_text(std::unordered_map<std::string, std::string> &alias_list);
     };
 
-    alias_parser parser;
+    AliasParser parser;
 
 };

--- a/include/alias_manager.hpp
+++ b/include/alias_manager.hpp
@@ -17,14 +17,14 @@
 class AliasManager {
 
 public:
-    static AliasManager *get_instance();
+    static AliasManager *getInstance();
 
-    bool has_alias(std::string filename);
-    std::string get_alias(std::string filename);
-    void set_alias(std::string filename, std::string alias);
-    void remove_alias(std::string filename);
-    void load_saved_alias(std::string filepath=SKYMM_NX_ALIAS_TXT_FILE);
-    void save_alias_list_to_disk(std::string dest=SKYMM_NX_ALIAS_TXT_FILE);
+    bool hasAlias(std::string filename);
+    std::string getAlias(std::string filename);
+    void setAlias(std::string filename, std::string alias);
+    void removeAlias(std::string filename);
+    void loadSavedAlias(std::string filepath=SKYMM_NX_ALIAS_TXT_FILE);
+    void saveAliasListToDisk(std::string dest=SKYMM_NX_ALIAS_TXT_FILE);
     
 
 private:
@@ -36,7 +36,7 @@ private:
     class AliasParser {
     public:
         void parse(std::string text);
-        std::string convert_to_text(std::unordered_map<std::string, std::string> &alias_list);
+        std::string convertToText(std::unordered_map<std::string, std::string> &alias_list);
     };
 
     AliasParser parser;

--- a/include/file_helper.hpp
+++ b/include/file_helper.hpp
@@ -5,7 +5,7 @@
 #include <streambuf>
 #include <sstream>
 
-class file_helper {
+class FileHelper {
 public:
     static std::string get_file_as_string(std::string filepath);
     static void save_string_to_file(std::string dest, std::string text);

--- a/include/file_helper.hpp
+++ b/include/file_helper.hpp
@@ -7,7 +7,7 @@
 
 class FileHelper {
 public:
-    static std::string get_file_as_string(std::string filepath);
-    static void save_string_to_file(std::string dest, std::string text);
+    static std::string getFileAsString(std::string filepath);
+    static void saveStringToFile(std::string dest, std::string text);
 };
 

--- a/include/file_helper.hpp
+++ b/include/file_helper.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include <fstream>
+#include <streambuf>
+#include <sstream>
+
+class file_helper {
+public:
+    static std::string get_file_as_string(std::string filepath);
+    static void save_string_to_file(std::string dest, std::string text);
+};
+

--- a/include/gui.hpp
+++ b/include/gui.hpp
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "alias_manager.hpp"
 #include "mod.hpp"
 
 #include <memory>

--- a/include/keyboard_helper.hpp
+++ b/include/keyboard_helper.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+#include <switch.h>
+
+#define MAX_INPUT_LENGTH 40
+
+class Keyboard {
+public:
+    static std::string show(std::string title, 
+                                std::string guide_msg, 
+                                std::string initial_string = std::string());
+};

--- a/include/keyboard_helper.hpp
+++ b/include/keyboard_helper.hpp
@@ -8,6 +8,10 @@
 
 class Keyboard {
 public:
+    static Result show(std::string &output_str,
+                        std::string title, 
+                        std::string guide_msg, 
+                        std::string initial_string = std::string());
     static std::string show(std::string title, 
                                 std::string guide_msg, 
                                 std::string initial_string = std::string());

--- a/include/mod.hpp
+++ b/include/mod.hpp
@@ -34,8 +34,15 @@
 #define EXT_ESM "esm"
 #define EXT_BSA "bsa"
 
+#define SUFFIX_ANIMATIONS_LONG "Animations"
+#define SUFFIX_MESHES_LONG "Meshes"
+#define SUFFIX_SOUNDS_LONG "Sounds"
+#define SUFFIX_TEXTURES_LONG "Textures"
+#define SUFFIX_VOICES_LONG "Voices"
+
 #define SUFFIX_ANIMATIONS "A"
 #define SUFFIX_MESHES "M"
+#define SUFFIX_NONE ""
 #define SUFFIX_SOUNDS "S"
 #define SUFFIX_TEXTURES "T"
 #define SUFFIX_VOICES "V"

--- a/include/mod.hpp
+++ b/include/mod.hpp
@@ -34,6 +34,12 @@
 #define EXT_ESM "esm"
 #define EXT_BSA "bsa"
 
+#define SUFFIX_ANIMATIONS "Animations"
+#define SUFFIX_MESHES "Meshes"
+#define SUFFIX_SOUNDS "Sounds"
+#define SUFFIX_TEXTURES "Textures"
+#define SUFFIX_VOICES "Voices"
+
 enum class ModStatus {
     ENABLED,
     DISABLED,

--- a/include/mod.hpp
+++ b/include/mod.hpp
@@ -34,11 +34,11 @@
 #define EXT_ESM "esm"
 #define EXT_BSA "bsa"
 
-#define SUFFIX_ANIMATIONS "Animations"
-#define SUFFIX_MESHES "Meshes"
-#define SUFFIX_SOUNDS "Sounds"
-#define SUFFIX_TEXTURES "Textures"
-#define SUFFIX_VOICES "Voices"
+#define SUFFIX_ANIMATIONS "A"
+#define SUFFIX_MESHES "M"
+#define SUFFIX_SOUNDS "S"
+#define SUFFIX_TEXTURES "T"
+#define SUFFIX_VOICES "V"
 
 enum class ModStatus {
     ENABLED,

--- a/include/path_helper.hpp
+++ b/include/path_helper.hpp
@@ -33,6 +33,9 @@
 #define SKYRIM_INI_FILE "Skyrim.ini"
 #define SKYRIM_INI_LANG_FILE_PREFIX "Skyrim_"
 #define SKYRIM_PLUGINS_FILE "Plugins"
+#define DIR_SEP "/"
+//#define SKYMM_NX_ALIAS_TXT_FILE "sdmc:/switch/skymm_nx_saved_alias.txt"
+#define SKYMM_NX_ALIAS_TXT_FILE "sdmc:/atmosphere/contents/01000A10041EA000/romfs/Data/skymm_aliases.txt"
 
 #define LANG_CODE_MAX_LEN 6
 

--- a/src/alias_manager.cpp
+++ b/src/alias_manager.cpp
@@ -58,7 +58,7 @@ void AliasManager::load_saved_alias(std::string filepath) {
     }
 
     std::string saved_text;
-    saved_text = file_helper::get_file_as_string(filepath);
+    saved_text = FileHelper::get_file_as_string(filepath);
     if (!saved_text.empty()) {
         this->parser.parse(saved_text);
     }
@@ -94,7 +94,7 @@ void AliasManager::AliasParser::parse(std::string text) {
 void AliasManager::save_alias_list_to_disk(std::string dest) {
     // maybe print relevant console message if saving fails
     std::string plaintext = this->parser.convert_to_text(this->filename_to_alias_mapping);
-    file_helper::save_string_to_file(dest, plaintext);
+    FileHelper::save_string_to_file(dest, plaintext);
 }
 
 std::string AliasManager::AliasParser::convert_to_text(std::unordered_map<std::string, std::string> &alias_list) {

--- a/src/alias_manager.cpp
+++ b/src/alias_manager.cpp
@@ -1,0 +1,91 @@
+#include "alias_manager.hpp"
+
+alias_manager::alias_manager() {
+    parser = alias_manager::alias_parser();
+}
+
+alias_manager* alias_manager::getInstance() {
+    if (!instance) {
+        instance = new alias_manager();
+    }
+    return instance;
+}
+
+bool alias_manager::has_alias(std::string filename) {
+    return this->filename_to_alias_mapping.find(filename) == this->filename_to_alias_mapping.end();
+}
+
+std::string alias_manager::get_alias(std::string filename) {
+    return has_alias(filename) ? filename_to_alias_mapping.at(filename)
+                                    : std::string();
+}
+
+void alias_manager::set_alias(std::string filename, std::string alias) {
+    if (alias.empty()) {
+        remove_alias(filename);
+        return;
+    }
+
+    if (!filename.empty()) {
+        filename_to_alias_mapping[filename] = alias;
+    }
+}
+
+void alias_manager::remove_alias(std::string filename) {
+    if (has_alias(filename)) {
+        this->filename_to_alias_mapping.erase(filename);
+    }
+}
+
+void alias_manager::load_saved_alias(std::string filepath) {
+    //try {
+    if (!this->filename_to_alias_mapping.empty()) {
+        this->filename_to_alias_mapping.clear();
+    }
+
+    std::string saved_text;
+    saved_text = file_helper::get_file_as_string(filepath);
+    this->parser.parse(saved_text);
+    //} catch (std::exception& e) {
+        // TODO: print relevant console stuff. 
+        // alias is not core functionality,
+        // so just catch all file handling exceptions here.
+    //}
+}
+
+void alias_manager::alias_parser::parse(std::string text) {
+    std::stringstream buffer = std::stringstream(text);
+
+    std::vector<std::string> entries = split(text, NEWLINE);
+
+    for (auto &entry : entries) {
+        std::vector<std::string> tokens = split(entry, SEPARATOR_TOKEN);
+        if (tokens.size() < 2 ||
+            tokens.at(0).empty() ||
+            tokens.at(1).empty()) {
+            continue;
+        }
+        alias_manager::getInstance()->set_alias(tokens.at(0), tokens.at(1));
+    }
+}
+
+void alias_manager::save_alias_list_to_disk(std::string dest) {
+    //try {
+    std::string plaintext = this->parser.convert_to_text(this->filename_to_alias_mapping);
+    file_helper::save_string_to_file(dest, plaintext);
+    //} catch (std::exception &e) {
+        // TODO print relevant error message on console
+    //}
+}
+
+std::string alias_manager::alias_parser::convert_to_text(std::unordered_map<std::string, std::string> &alias_list) {
+    if (alias_list.empty()) {
+        return std::string();
+    }
+
+    std::stringstream s;
+    for (auto &entry : alias_list) {
+        s << entry.first << SPACE << SEPARATOR_TOKEN << SPACE << entry.second << "\n";
+    }
+    return s.str();
+}

--- a/src/alias_manager.cpp
+++ b/src/alias_manager.cpp
@@ -14,7 +14,7 @@ AliasManager* AliasManager::get_instance() {
 }
 
 bool AliasManager::has_alias(std::string filename) {
-    return this->filename_to_alias_mapping.find(filename) == this->filename_to_alias_mapping.end();
+    return this->filename_to_alias_mapping.find(filename) != this->filename_to_alias_mapping.end();
 }
 
 std::string AliasManager::get_alias(std::string filename) {

--- a/src/alias_manager.cpp
+++ b/src/alias_manager.cpp
@@ -1,59 +1,70 @@
 #include "alias_manager.hpp"
 
-alias_manager::alias_manager() {
-    parser = alias_manager::alias_parser();
+AliasManager* AliasManager::instance = 0;
+
+AliasManager::AliasManager() {
+    parser = AliasManager::AliasParser();
 }
 
-alias_manager* alias_manager::getInstance() {
+AliasManager* AliasManager::get_instance() {
     if (!instance) {
-        instance = new alias_manager();
+        instance = new AliasManager();
     }
     return instance;
 }
 
-bool alias_manager::has_alias(std::string filename) {
+bool AliasManager::has_alias(std::string filename) {
     return this->filename_to_alias_mapping.find(filename) == this->filename_to_alias_mapping.end();
 }
 
-std::string alias_manager::get_alias(std::string filename) {
+std::string AliasManager::get_alias(std::string filename) {
     return has_alias(filename) ? filename_to_alias_mapping.at(filename)
                                     : std::string();
 }
 
-void alias_manager::set_alias(std::string filename, std::string alias) {
+void AliasManager::set_alias(std::string filename, std::string alias) {
+    // programmer error, empty base_name passed in
+    if (filename.empty()) {
+        return;
+    }
+
+    // remove alias
     if (alias.empty()) {
         remove_alias(filename);
         return;
     }
 
-    if (!filename.empty()) {
-        filename_to_alias_mapping[filename] = alias;
+    // alias remains the same
+    if (this->has_alias(filename) 
+        && this->filename_to_alias_mapping.at(filename) == alias) {
+        return;
     }
+
+    // otherwise, change the alias and rewrite saved txt file
+    filename_to_alias_mapping[filename] = alias;
+    this->save_alias_list_to_disk();
 }
 
-void alias_manager::remove_alias(std::string filename) {
+void AliasManager::remove_alias(std::string filename) {
     if (has_alias(filename)) {
         this->filename_to_alias_mapping.erase(filename);
     }
 }
 
-void alias_manager::load_saved_alias(std::string filepath) {
-    //try {
+void AliasManager::load_saved_alias(std::string filepath) {
+    // maybe print relevant message if loading fails
     if (!this->filename_to_alias_mapping.empty()) {
         this->filename_to_alias_mapping.clear();
     }
 
     std::string saved_text;
     saved_text = file_helper::get_file_as_string(filepath);
-    this->parser.parse(saved_text);
-    //} catch (std::exception& e) {
-        // TODO: print relevant console stuff. 
-        // alias is not core functionality,
-        // so just catch all file handling exceptions here.
-    //}
+    if (!saved_text.empty()) {
+        this->parser.parse(saved_text);
+    }
 }
 
-void alias_manager::alias_parser::parse(std::string text) {
+void AliasManager::AliasParser::parse(std::string text) {
     std::stringstream buffer = std::stringstream(text);
 
     std::vector<std::string> entries = split(text, NEWLINE);
@@ -65,20 +76,28 @@ void alias_manager::alias_parser::parse(std::string text) {
             tokens.at(1).empty()) {
             continue;
         }
-        alias_manager::getInstance()->set_alias(tokens.at(0), tokens.at(1));
+
+        std::string mod_name = tokens.at(0);
+        std::string alias = tokens.at(1);
+
+        // for the case when user uses a separator token in alias
+        if (tokens.size() > 2) {
+            for (unsigned long i = 2; i < tokens.size(); i++) {
+                alias += tokens.at(i);
+            }
+        }
+
+        AliasManager::get_instance()->set_alias(mod_name, alias);
     }
 }
 
-void alias_manager::save_alias_list_to_disk(std::string dest) {
-    //try {
+void AliasManager::save_alias_list_to_disk(std::string dest) {
+    // maybe print relevant console message if saving fails
     std::string plaintext = this->parser.convert_to_text(this->filename_to_alias_mapping);
     file_helper::save_string_to_file(dest, plaintext);
-    //} catch (std::exception &e) {
-        // TODO print relevant error message on console
-    //}
 }
 
-std::string alias_manager::alias_parser::convert_to_text(std::unordered_map<std::string, std::string> &alias_list) {
+std::string AliasManager::AliasParser::convert_to_text(std::unordered_map<std::string, std::string> &alias_list) {
     if (alias_list.empty()) {
         return std::string();
     }

--- a/src/alias_manager.cpp
+++ b/src/alias_manager.cpp
@@ -6,23 +6,23 @@ AliasManager::AliasManager() {
     parser = AliasManager::AliasParser();
 }
 
-AliasManager* AliasManager::get_instance() {
+AliasManager* AliasManager::getInstance() {
     if (!instance) {
         instance = new AliasManager();
     }
     return instance;
 }
 
-bool AliasManager::has_alias(std::string filename) {
+bool AliasManager::hasAlias(std::string filename) {
     return this->filename_to_alias_mapping.find(filename) != this->filename_to_alias_mapping.end();
 }
 
-std::string AliasManager::get_alias(std::string filename) {
-    return has_alias(filename) ? filename_to_alias_mapping.at(filename)
+std::string AliasManager::getAlias(std::string filename) {
+    return hasAlias(filename) ? filename_to_alias_mapping.at(filename)
                                     : std::string();
 }
 
-void AliasManager::set_alias(std::string filename, std::string alias) {
+void AliasManager::setAlias(std::string filename, std::string alias) {
     // programmer error, empty base_name passed in
     if (filename.empty()) {
         return;
@@ -30,35 +30,35 @@ void AliasManager::set_alias(std::string filename, std::string alias) {
 
     // remove alias
     if (alias.empty()) {
-        remove_alias(filename);
+        this->removeAlias(filename);
         return;
     }
 
     // alias remains the same
-    if (this->has_alias(filename) 
+    if (this->hasAlias(filename) 
         && this->filename_to_alias_mapping.at(filename) == alias) {
         return;
     }
 
     // otherwise, change the alias and rewrite saved txt file
     filename_to_alias_mapping[filename] = alias;
-    this->save_alias_list_to_disk();
+    this->saveAliasListToDisk();
 }
 
-void AliasManager::remove_alias(std::string filename) {
-    if (has_alias(filename)) {
+void AliasManager::removeAlias(std::string filename) {
+    if (this->hasAlias(filename)) {
         this->filename_to_alias_mapping.erase(filename);
     }
 }
 
-void AliasManager::load_saved_alias(std::string filepath) {
+void AliasManager::loadSavedAlias(std::string filepath) {
     // maybe print relevant message if loading fails
     if (!this->filename_to_alias_mapping.empty()) {
         this->filename_to_alias_mapping.clear();
     }
 
     std::string saved_text;
-    saved_text = FileHelper::get_file_as_string(filepath);
+    saved_text = FileHelper::getFileAsString(filepath);
     if (!saved_text.empty()) {
         this->parser.parse(saved_text);
     }
@@ -87,17 +87,17 @@ void AliasManager::AliasParser::parse(std::string text) {
             }
         }
 
-        AliasManager::get_instance()->set_alias(mod_name, alias);
+        AliasManager::getInstance()->setAlias(mod_name, alias);
     }
 }
 
-void AliasManager::save_alias_list_to_disk(std::string dest) {
+void AliasManager::saveAliasListToDisk(std::string dest) {
     // maybe print relevant console message if saving fails
-    std::string plaintext = this->parser.convert_to_text(this->filename_to_alias_mapping);
-    FileHelper::save_string_to_file(dest, plaintext);
+    std::string plaintext = this->parser.convertToText(this->filename_to_alias_mapping);
+    FileHelper::saveStringToFile(dest, plaintext);
 }
 
-std::string AliasManager::AliasParser::convert_to_text(std::unordered_map<std::string, std::string> &alias_list) {
+std::string AliasManager::AliasParser::convertToText(std::unordered_map<std::string, std::string> &alias_list) {
     if (alias_list.empty()) {
         return std::string();
     }

--- a/src/file_helper.cpp
+++ b/src/file_helper.cpp
@@ -1,6 +1,6 @@
 #include "file_helper.hpp"
 
-std::string FileHelper::get_file_as_string(std::string filepath) {
+std::string FileHelper::getFileAsString(std::string filepath) {
     std::ifstream t(filepath);
 
     if (t) {
@@ -13,7 +13,7 @@ std::string FileHelper::get_file_as_string(std::string filepath) {
     return std::string();
 }
 
-void FileHelper::save_string_to_file(std::string dest, std::string text) {
+void FileHelper::saveStringToFile(std::string dest, std::string text) {
     std::ofstream t(dest);
     t << text;
     t.close();

--- a/src/file_helper.cpp
+++ b/src/file_helper.cpp
@@ -1,12 +1,16 @@
 #include "file_helper.hpp"
 
 std::string file_helper::get_file_as_string(std::string filepath) {
-    std::stringstream buffer;
     std::ifstream t(filepath);
 
-    buffer << t.rdbuf();
-    t.close();
-    return buffer.str();
+    if (t) {
+        std::stringstream buffer;
+        buffer << t.rdbuf();
+        t.close();
+        return buffer.str();
+    }
+
+    return std::string();
 }
 
 void file_helper::save_string_to_file(std::string dest, std::string text) {

--- a/src/file_helper.cpp
+++ b/src/file_helper.cpp
@@ -1,0 +1,16 @@
+#include "file_helper.hpp"
+
+std::string file_helper::get_file_as_string(std::string filepath) {
+    std::stringstream buffer;
+    std::ifstream t(filepath);
+
+    buffer << t.rdbuf();
+    t.close();
+    return buffer.str();
+}
+
+void file_helper::save_string_to_file(std::string dest, std::string text) {
+    std::ofstream t(dest);
+    t << text;
+    t.close();
+}

--- a/src/file_helper.cpp
+++ b/src/file_helper.cpp
@@ -1,6 +1,6 @@
 #include "file_helper.hpp"
 
-std::string file_helper::get_file_as_string(std::string filepath) {
+std::string FileHelper::get_file_as_string(std::string filepath) {
     std::ifstream t(filepath);
 
     if (t) {
@@ -13,7 +13,7 @@ std::string file_helper::get_file_as_string(std::string filepath) {
     return std::string();
 }
 
-void file_helper::save_string_to_file(std::string dest, std::string text) {
+void FileHelper::save_string_to_file(std::string dest, std::string text) {
     std::ofstream t(dest);
     t << text;
     t.close();

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -133,6 +133,7 @@ void ModGui::redrawRow(size_t gui_y) {
 
     // display alias in brackets if present
     if (AliasManager::get_instance()->has_alias(cur_mod->base_name)) {
+        CONSOLE_SET_COLOR(CONSOLE_COLOR_FG_CYAN);
         printf((" (" 
                 + AliasManager::get_instance()->get_alias(cur_mod->base_name) 
                 + ")")

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -130,6 +130,15 @@ void ModGui::redrawRow(size_t gui_y) {
     }
 
     printf(cur_mod->base_name.c_str());
+
+    // display alias in brackets if present
+    if (AliasManager::get_instance()->has_alias(cur_mod->base_name)) {
+        printf((" (" 
+                + AliasManager::get_instance()->get_alias(cur_mod->base_name) 
+                + ")")
+                .c_str());
+    }
+
     printf("\n");
 
     CONSOLE_SET_ATTRS(CONSOLE_ATTR_BOLD);

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -132,10 +132,10 @@ void ModGui::redrawRow(size_t gui_y) {
     printf(cur_mod->base_name.c_str());
 
     // display alias in brackets if present
-    if (AliasManager::get_instance()->has_alias(cur_mod->base_name)) {
+    if (AliasManager::getInstance()->hasAlias(cur_mod->base_name)) {
         CONSOLE_SET_COLOR(CONSOLE_COLOR_FG_CYAN);
         printf((" (" 
-                + AliasManager::get_instance()->get_alias(cur_mod->base_name) 
+                + AliasManager::getInstance()->getAlias(cur_mod->base_name) 
                 + ")")
                 .c_str());
     }

--- a/src/ini_helper.cpp
+++ b/src/ini_helper.cpp
@@ -36,9 +36,11 @@
 #include <fstream>
 #include <memory>
 
-static const std::vector<std::string> g_archive_types_1 = {"", SUFFIX_ANIMATIONS, SUFFIX_MESHES, SUFFIX_SOUNDS};
-static const std::vector<std::string> g_archive_types_2 = {SUFFIX_TEXTURES, SUFFIX_VOICES};
-static const std::vector<std::string> g_archive_types_3 = {SUFFIX_ANIMATIONS};
+static const std::vector<std::string> g_archive_types_1 = {SUFFIX_NONE, SUFFIX_ANIMATIONS, SUFFIX_MESHES, SUFFIX_SOUNDS,
+                                                            SUFFIX_ANIMATIONS_LONG, SUFFIX_MESHES_LONG, SUFFIX_SOUNDS_LONG};
+static const std::vector<std::string> g_archive_types_2 = {SUFFIX_TEXTURES, SUFFIX_VOICES, 
+                                                            SUFFIX_TEXTURES_LONG, SUFFIX_VOICES_LONG};
+static const std::vector<std::string> g_archive_types_3 = {SUFFIX_ANIMATIONS, SUFFIX_ANIMATIONS_LONG};
 
 static StdIni g_skyrim_ini;
 static StdIni g_skyrim_lang_ini;

--- a/src/ini_helper.cpp
+++ b/src/ini_helper.cpp
@@ -138,7 +138,7 @@ int processIniDefs(ModList &final_mod_list, ModList &temp_mod_list, StdIni &ini,
 
         bool good_suffix = false;
         for (std::string expected_suffix : expected_suffixes) {
-            if (mod_file.suffix.find_last_of(expected_suffix, expected_suffix.size())) {
+            if (mod_file.suffix == expected_suffix) {
                 good_suffix = true;
                 break;
             }
@@ -202,7 +202,7 @@ static int writeFileList(const char *path, StdIni &ini, std::string key,
     for (std::shared_ptr<SkyrimMod> mod : getGlobalModList()) {
         for (std::pair<std::string, int> suffix_pair : mod->enabled_bsas) {
             for (std::string expected_suffix : expected_suffixes) {
-                if (suffix_pair.first.find(expected_suffix) == 0) {
+                if (suffix_pair.first == expected_suffix) {
                     file_list.insert(file_list.end(), {mod->is_master ? ModFileType::ESM : ModFileType::ESP, mod->base_name, suffix_pair.first});
                     break;
                 }

--- a/src/ini_helper.cpp
+++ b/src/ini_helper.cpp
@@ -36,9 +36,9 @@
 #include <fstream>
 #include <memory>
 
-static const std::vector<std::string> g_archive_types_1 = {"", "Animations", "Meshes", "Sounds"};
-static const std::vector<std::string> g_archive_types_2 = {"Textures", "Voices"};
-static const std::vector<std::string> g_archive_types_3 = {"Animations"};
+static const std::vector<std::string> g_archive_types_1 = {"", SUFFIX_ANIMATIONS, SUFFIX_MESHES, SUFFIX_SOUNDS};
+static const std::vector<std::string> g_archive_types_2 = {SUFFIX_TEXTURES, SUFFIX_VOICES};
+static const std::vector<std::string> g_archive_types_3 = {SUFFIX_ANIMATIONS};
 
 static StdIni g_skyrim_ini;
 static StdIni g_skyrim_lang_ini;

--- a/src/ini_helper.cpp
+++ b/src/ini_helper.cpp
@@ -138,7 +138,7 @@ int processIniDefs(ModList &final_mod_list, ModList &temp_mod_list, StdIni &ini,
 
         bool good_suffix = false;
         for (std::string expected_suffix : expected_suffixes) {
-            if (mod_file.suffix.find_last_of(expected_suffix, expected_suffix.size())) {
+            if (mod_file.suffix == expected_suffix) {
                 good_suffix = true;
                 break;
             }

--- a/src/keyboard_helper.cpp
+++ b/src/keyboard_helper.cpp
@@ -1,0 +1,25 @@
+#include "keyboard_helper.hpp"
+
+std::string Keyboard::show(std::string title, 
+                            std::string guide_msg, 
+                            std::string initial_string) {
+    Result rc = 0;
+    SwkbdConfig kbd;
+    char tmpoutstr[MAX_INPUT_LENGTH] = {0};
+    rc = swkbdCreate(&kbd, 0);
+
+    if (R_SUCCEEDED(rc)) {
+        swkbdConfigMakePresetDefault(&kbd);
+        swkbdConfigSetHeaderText(&kbd, title.c_str());
+        swkbdConfigSetGuideText(&kbd, guide_msg.c_str());
+        swkbdConfigSetInitialText(&kbd, initial_string.c_str());
+
+        rc = swkbdShow(&kbd, tmpoutstr, sizeof(tmpoutstr));
+        swkbdClose(&kbd);
+
+        return R_SUCCEEDED(rc) ? std::string(tmpoutstr)
+                                : std::string();
+    }
+
+    return std::string();
+}

--- a/src/keyboard_helper.cpp
+++ b/src/keyboard_helper.cpp
@@ -1,6 +1,7 @@
 #include "keyboard_helper.hpp"
 
-std::string Keyboard::show(std::string title, 
+Result Keyboard::show(std::string &output_str,
+                            std::string title, 
                             std::string guide_msg, 
                             std::string initial_string) {
     Result rc = 0;
@@ -17,9 +18,18 @@ std::string Keyboard::show(std::string title,
         rc = swkbdShow(&kbd, tmpoutstr, sizeof(tmpoutstr));
         swkbdClose(&kbd);
 
-        return R_SUCCEEDED(rc) ? std::string(tmpoutstr)
+        output_str = R_SUCCEEDED(rc) ? std::string(tmpoutstr)
                                 : std::string();
     }
 
-    return std::string();
+    return rc;
 }
+
+std::string Keyboard::show(std::string title, 
+                            std::string guide_msg, 
+                            std::string initial_string) {
+    std::string output_str;
+    Keyboard::show(output_str, title, guide_msg, initial_string);
+    return output_str;
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -221,7 +221,7 @@ int initialize(void) {
     printf("Attempting to retrieve mod aliases, if any...\n");
 
     // load alias file
-    AliasManager::get_instance()->load_saved_alias(SKYMM_NX_ALIAS_TXT_FILE);
+    AliasManager::getInstance()->loadSavedAlias(SKYMM_NX_ALIAS_TXT_FILE);
 
     printf("Discovering available mods...\n");
 
@@ -496,27 +496,33 @@ int main(int argc, char **argv) {
         if (kDown & HidNpadButton_X) {
             //find out which mod was selected
             std::shared_ptr<SkyrimMod> mod = gui.getSelectedMod();
+            bool currently_has_alias = AliasManager::getInstance()->hasAlias(mod->base_name);
             //bring up keyboard and capture input
-            std::string retstr = Keyboard::show("Enter new alias for '" 
+            std::string retstr = Keyboard::show("Enter new alias for '" // title
                                                     + mod->base_name
-                                                    + ((AliasManager::get_instance()->has_alias(mod->base_name)) 
-                                                                ? " (" + 
-                                                                    AliasManager::get_instance()->get_alias(mod->base_name) 
+                                                    + ((currently_has_alias) ? " (" + 
+                                                                    AliasManager::getInstance()
+                                                                                ->getAlias(mod->base_name) 
                                                                     + ")'"
                                                                 : "'"),
-                                                                
+                                                // guide text                
                                                 "New Alias (MAX: " 
                                                 + std::to_string(MAX_INPUT_LENGTH) 
-                                                + " characters)");
+                                                + " characters)",
+                                                // initial starting text
+                                                (currently_has_alias) ? AliasManager::getInstance()
+                                                                        ->getAlias(mod->base_name)
+                                                                : std::string());
 
             //save alias
-            AliasManager::get_instance()->set_alias(mod->base_name, retstr);
+            AliasManager::getInstance()->setAlias(mod->base_name, retstr);
 
             //push updates to display
             gui.redrawCurrentRow();
             g_status_msg = (retstr.empty())? "Alias successfully removed."
                                                 : "Alias successfully set.";
             redrawFooter();
+            clearTempEffects();
         }
 
         consoleUpdate(NULL);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -498,30 +498,35 @@ int main(int argc, char **argv) {
             std::shared_ptr<SkyrimMod> mod = gui.getSelectedMod();
             bool currently_has_alias = AliasManager::getInstance()->hasAlias(mod->base_name);
             //bring up keyboard and capture input
-            std::string retstr = Keyboard::show("Enter new alias for '" // title
-                                                    + mod->base_name
-                                                    + ((currently_has_alias) ? " (" + 
-                                                                    AliasManager::getInstance()
-                                                                                ->getAlias(mod->base_name) 
-                                                                    + ")'"
-                                                                : "'"),
-                                                // guide text                
-                                                "New Alias (MAX: " 
-                                                + std::to_string(MAX_INPUT_LENGTH) 
-                                                + " characters)",
-                                                // initial starting text
-                                                (currently_has_alias) ? AliasManager::getInstance()
-                                                                        ->getAlias(mod->base_name)
-                                                                : std::string());
+            std::string retstr;
+            Result rc = Keyboard::show(retstr,
+                                        // title
+                                        "Enter new alias for '"
+                                            + mod->base_name
+                                            + ((currently_has_alias) ? " (" 
+                                                                        + AliasManager::getInstance()
+                                                                            ->getAlias(mod->base_name) 
+                                                                        + ")'"
+                                                                    : "'"),
+                                        // guide text                
+                                         "New Alias (MAX: " 
+                                        + std::to_string(MAX_INPUT_LENGTH) 
+                                        + " characters)",
+                                        // initial starting text
+                                        (currently_has_alias) ? AliasManager::getInstance()
+                                                                ->getAlias(mod->base_name)
+                                                            : std::string());
 
-            //save alias
-            AliasManager::getInstance()->setAlias(mod->base_name, retstr);
+            if (R_SUCCEEDED(rc)) {
+                //save alias
+                AliasManager::getInstance()->setAlias(mod->base_name, retstr);
 
-            //push updates to display
-            gui.redrawCurrentRow();
-            g_status_msg = (retstr.empty())? "Alias successfully removed."
+                //push updates to display
+                gui.redrawCurrentRow();
+                g_status_msg = (retstr.empty())? "Alias successfully removed."
                                                 : "Alias successfully set.";
-            redrawFooter();
+                redrawFooter();
+            }
             clearTempEffects();
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,9 +269,15 @@ static void redrawHeader(void) {
     CONSOLE_CLEAR_LINE();
     CONSOLE_SET_COLOR(CONSOLE_COLOR_FG_CYAN);
     printf("SkyMM-NX v" STRINGIZE(__VERSION) " by caseif");
+    CONSOLE_SET_COLOR(CONSOLE_COLOR_FG_MAGENTA);
+    printf(", modified by SundayReds");
+    CONSOLE_MOVE_DOWN(1);
+    CONSOLE_MOVE_LEFT(255);
     CONSOLE_SET_COLOR(CONSOLE_COLOR_FG_WHITE);
+    printf("NOTE: Shorten suffixes eg. 'Mod - Meshes.bsa' should be 'Mod - M.bsa'.");
 
-    CONSOLE_MOVE_DOWN(2);
+
+    CONSOLE_MOVE_DOWN(1);
     CONSOLE_MOVE_LEFT(255);
     printf(HRULE);
 }

--- a/src/mod.cpp
+++ b/src/mod.cpp
@@ -86,7 +86,7 @@ ModStatus SkyrimMod::getStatus(void) {
     } else {
         bool bad_anims = false;
         for (auto bsa_pair : enabled_bsas) {
-            if (bsa_pair.first.find("Animations") == 0 && bsa_pair.second != 2) {
+            if (bsa_pair.first.find(SUFFIX_ANIMATIONS) == 0 && bsa_pair.second != 2) {
                 bsa_status = ModStatus::PARTIAL;
                 bad_anims = true;
                 break;
@@ -114,7 +114,7 @@ ModStatus SkyrimMod::getStatus(void) {
 void SkyrimMod::enable(void) {
     enabled_bsas.clear();
     for (std::string bsa : bsa_suffixes) {
-        int count = bsa.find("Animations") == 0 ? 2 : 1;
+        int count = bsa.find(SUFFIX_ANIMATIONS) == 0 ? 2 : 1;
         enabled_bsas.insert(std::pair(bsa, count));
     }
 


### PR DESCRIPTION
Added a feature to give each mod an in-app alias. Pressing `X` while hovering over a mod prompts user to add an alias to the mod, which will then be saved to disk and then loaded up the next time. Entering an empty alias will delete the current alias, if any, associated with the selected mod. The aliases will be saved in a human-readable format in `skymm-alias.txt` within the same folder. which the user can opt to edit directly instead of going through the app.

- eg. Mod `A` as displayed in-app can now be given the alias `Crossbows of Skyrim`, which will display in-app as `A (Crossbows of Skyrim)`. The alias will be saved in a human-readable format in `skymm-alias.txt` within the same folder. The user can opt to edit the `.txt` directly instead of doing through the application as well.


**Purpose:** Allows user to shorten base names of mods as much as they want without running the risk of forgetting what the shortened names stood for.

close #1 